### PR TITLE
Add end_time to Call model

### DIFF
--- a/bandwidth_sdk/models.py
+++ b/bandwidth_sdk/models.py
@@ -112,10 +112,11 @@ class Call(AudioMixin, GenericResource):
     state = None
     start_time = None
     active_time = None
+    end_time = None
     client = None
     bridge_id = None
     _fields = frozenset(('call_id', 'direction', 'from_', 'to', 'recording_enabled', 'callback_url',
-                         'state', 'start_time', 'active_time', 'bridge_id'))
+                         'state', 'start_time', 'active_time', 'end_time', 'bridge_id'))
 
     def __init__(self, data):
         self.client = get_client()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -50,6 +50,7 @@ class CallsTest(SdkTestCase):
         "callbackUrl": "",
         "state": "active",
         "startTime": "2013-02-08T13:15:47.587Z",
+        "endTime": "2013-02-08T13:15:57.347Z",
         "activeTime": "2013-02-08T13:15:52.347Z",
         "events": "https://.../calls/{callId}/events"
         }
@@ -68,6 +69,7 @@ class CallsTest(SdkTestCase):
         self.assertEqual(call.to, '+1919000002')
         self.assertEqual(call.recording_enabled, False)
         self.assertEqual(call.state, 'active')
+        self.assertEqual((call.end_time - call.active_time).seconds, 5)
 
     @responses.activate
     def test_get_and_not_found(self):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -69,7 +69,9 @@ class CallsTest(SdkTestCase):
         self.assertEqual(call.to, '+1919000002')
         self.assertEqual(call.recording_enabled, False)
         self.assertEqual(call.state, 'active')
-        self.assertEqual((call.end_time - call.active_time).seconds, 5)
+        self.assertEqual(
+            call.end_time.strftime('%Y-%m-%d %H:%M:%S'),
+            '2013-02-08 13:15:57')
 
     @responses.activate
     def test_get_and_not_found(self):


### PR DESCRIPTION
Need to compute a call's duration. Can we add end_time to the Call model?