### PR TITLE
removed unused RESTClientObject.application_id

### DIFF
--- a/bandwidth_sdk/rest.py
+++ b/bandwidth_sdk/rest.py
@@ -36,7 +36,6 @@ class RESTClientObject(object):
         self.log_hook = log_hook
         self.uid = user_id
         self.auth = auth
-        self.application_id = None
         self.log = log or logger
 
     def _log_response(self, response):


### PR DESCRIPTION
RESTClientObject stores an unused instance variable `application_id`.