### PR TITLE
Revert "Add lxml to setup.y install_requires"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ setup(
         'Programming Language :: Python :: Implementation :: PyPy',
     ],
     install_requires=[
-        'lxml',
         'requests',
         'python-dateutil',
         'six'


### PR DESCRIPTION
Reverts bandwidthcom/python-bandwidth#33

Breaks pypy.  Consider removing lxml in later versions of the sdk.