### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/bandwidth_sdk/models.py
+++ b/bandwidth_sdk/models.py
@@ -211,7 +211,7 @@ class Call(AudioMixin, GenericResource):
         return [cls(v) for v in data_as_list]
 
     def __repr__(self):
-        return 'Call(%r, state=%r)' % (self.call_id, self.state or 'Unknown')
+        return 'Call({0!r}, state={1!r})'.format(self.call_id, self.state or 'Unknown')
 
     def get_audio_url(self):
         return '{}/{}/audio'.format(self.path, self.call_id)
@@ -781,7 +781,7 @@ class Conference(AudioMixin, CreateResource):
         return cls(data_as_dict)
 
     def __repr__(self):
-        return 'Conference(%r, state=%r)' % (self.id, self.state or 'Unknown')
+        return 'Conference({0!r}, state={1!r})'.format(self.id, self.state or 'Unknown')
 
     def update(self, **params):
         """
@@ -894,7 +894,7 @@ class ConferenceMember(AudioMixin, BaseResource):
         return self
 
     def __repr__(self):  # pragma: no cover
-        return 'ConferenceMember(%r, state=%r)' % (self.id, self.state or 'Unknown')
+        return 'ConferenceMember({0!r}, state={1!r})'.format(self.id, self.state or 'Unknown')
 
     def get_audio_url(self):
         return 'conferences/{}/members/{}/audio'.format(self.conf_id, self.id)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -14,7 +14,7 @@ from six.moves.urllib.parse import parse_qsl, urlsplit
 
 
 def assertJsonEq(first, second, msg='Ouups'):
-    assert sorted(first) == sorted(second), '%r != %r\n%s' % (first,
+    assert sorted(first) == sorted(second), '{0!r} != {1!r}\n{2!s}'.format(first,
                                                               second,
                                                               msg)
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:bandwidthcom:python-bandwidth?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:bandwidthcom:python-bandwidth?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)