### PR TITLE
Retrieve content-type header with .get

### DIFF
--- a/bandwidth_sdk/rest.py
+++ b/bandwidth_sdk/rest.py
@@ -53,7 +53,7 @@ class RESTClientObject(object):
         except requests.exceptions.HTTPError:
             self.log.exception('Error from bandwidth api.')
             template = '{} client error: {}' if response.status_code < 500 else '{} server error: {}'
-            if response.headers['content-type'] == 'application/json':
+            if response.headers.get('content-type') == 'application/json':
                 message = template.format(response.status_code, response.json()['message'])
             else:
                 message = template.format(response.status_code, response.content.decode('ascii')[:79])


### PR DESCRIPTION
Seeing a `KeyError` on a 503 response that points to there being no content-type in the headers. It is safer to use `get` to check for the content-type header.