### PR TITLE
remove pypy language from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ python:
   - "2.7"
   - "3.3"
   - "3.4"
-  - "pypy"
 # command to install dependencies
 install:
   - pip install .


### PR DESCRIPTION
Travis builds fail because deps consistently fail to install with pypi.  We probably don't need to support pypi.