### PR TITLE
Renames BXML SendMessage attributes to reflect API (Issue #48)

### DIFF
--- a/bandwidth_sdk/xml.py
+++ b/bandwidth_sdk/xml.py
@@ -273,9 +273,9 @@ class SendMessage(object):
         self._param = OrderedDict()
         self.text = text
         if from_number is not None:
-            self._param["from_number"] = str(from_number)
+            self._param["from"] = str(from_number)
         if to_number is not None:
-            self._param["to_number"] = str(to_number)
+            self._param["to"] = str(to_number)
         if status_callback_url is not None:
             self._param["statusCallbackUrl"] = str(status_callback_url)
         if request_url is not None:

--- a/tests/test_xml.py
+++ b/tests/test_xml.py
@@ -208,7 +208,7 @@ class XmlTest(SdkTestCase):
     def test_send_message_xml(self):
         expected_result = str.encode("<?xml version=\'1.0\' encoding=\'ASCII\'?>\n"
                                      "<Response>\n"
-                                     "  <SendMessage from_number=\"+19994444\" to_number=\"+144445555\">"
+                                     "  <SendMessage from=\"+19994444\" to=\"+144445555\">"
                                      "Message to send</SendMessage>\n"
                                      "</Response>\n")
 


### PR DESCRIPTION
Addresses #48.
From http://ap.bandwidth.com/docs/xml/message/
```
<?xml version="1.0" encoding="UTF-8"?>
<Response>
<SendMessage from="+1234567891" to="+1234567890">
This is the message text
</SendMessage>
</Response>
```
the API expects the attributes `from` and `to` but the library erroneously output `from_number` and `to_number`.

This fix renames the attributes, and includes the updated test.